### PR TITLE
docs: 对齐 v1.36 release.md 与 website PR #55151 最新稿

### DIFF
--- a/kubernetes/sig-release/v1.36/release.md
+++ b/kubernetes/sig-release/v1.36/release.md
@@ -1,133 +1,107 @@
-# Kubernetes v1.36 正式发布稿（精简版草案）
+# Kubernetes v1.36 正式发布稿（对齐 release announcement 最新草稿）
 
-> 写作基线：截至 2026-04-07 的上游公开信息与 `kubernetes/sig-release#2958` 讨论内容。v1.36 计划发布时间为 2026-04-22（周三），正式发布当天请以 CHANGELOG 和 release notes 为准。
+> 写作基线：截至 **2026-04-20** 的上游公开信息，重点对齐 `kubernetes/website#55151`（updated at 2026-04-19）与 `kubernetes/sig-release#2958`。v1.36 计划发布时间为 **2026-04-22（周三）**，请以 GA 当日 CHANGELOG 与 release notes 为准。
 
-本文结构按“前瞻精简 + highlights 展开”组织：
-- 前瞻里已经提到的内容，在这里做升级必读级别的精简提示。
-- `#2958` 讨论中的重点功能作为正文主线，提供相对完整说明。
+## 一、升级必读（前瞻内容精简）
 
-## 一、升级必读（来自 prerelease，精简版）
+### 弃用与移除
 
-### 1) 弃用与移除
+- `Service.spec.externalIPs`：v1.36 开始弃用并给出告警，计划 v1.43 移除。建议迁移到 `LoadBalancer`、`NodePort` 或 `Gateway API`（KEP-5707）。
+- `gitRepo` 卷驱动：v1.36 起永久禁用且不可重新启用。建议迁移为 `initContainer`、镜像构建打包或外部 `git-sync`（KEP-5040）。
 
-- `Service.spec.externalIPs`：v1.36 开始弃用并给出告警，计划 v1.43 移除。建议迁移到 `LoadBalancer`、`NodePort` 或 `Gateway API`。（KEP-5707）
-- `gitRepo` 卷驱动：v1.36 起永久禁用且不可重新启用。建议改为 `initContainer`、镜像构建阶段打包或外部 `git-sync`。（KEP-5040）
+### 生态风险提示
 
-### 2) 生态风险提示
+- Ingress NGINX 已于 2026 年 3 月 24 日退役，不再发布后续修复与安全更新。现网可继续运行，但应尽快推进迁移。
 
-- Ingress NGINX 已在 2026 年 3 月退役，不再提供后续修复和安全更新。现网可继续运行，但建议尽快完成迁移方案评估。
+## 二、与 #55151 最新版本对齐的发布主线
 
-## 二、Highlights Discussion 重点功能（展开版）
+根据 `kubernetes/website#55151` 当前草稿，v1.36 发布叙事已形成以下结构：
 
-### 重点一：Mutating Admission Policies 升级到 GA（KEP-3962）
+- 增强总量：**70**。
+- 升级到 Stable：**18**。
+- 升级到 Beta：**25**。
+- 升级到 Alpha：**25**。
 
-过去很多团队依赖 mutating webhook 做策略注入、默认值补全和安全控制，但 webhook 体系本身有明显运维成本：需要额外部署与证书管理、故障会放大 API 请求路径风险、升级和排障链路也更长。对于多集群平台，这类“外置准入逻辑”通常是稳定性薄弱点之一。
+### Spotlight（官方草稿当前重点）
 
-v1.36 中，基于 CEL 的 Mutating Admission Policies 进入 GA，意味着“声明式、进程内”的变更准入能力进入稳定阶段。它与已 GA 的 Validating Admission Policy 形成闭环，让集群在“校验 + 变更”两个环节都能减少对外部 webhook 的硬依赖。对平台团队来说，最直接价值是把一部分高频、可声明化的准入逻辑收敛到 apiserver 内部能力，降低控制面外围组件复杂度。
+- Stable：Fine-grained Kubelet API authorization（KEP-2862）。
+- Beta：Resource Health Status（KEP-4680）。
+- Alpha：Workload Aware Scheduling（WAS）系列能力（含 KEP-4671/5547/5832/5732/5710）。
 
-落地上建议采用分层迁移：先从无副作用、纯字段变换的 webhook 规则迁入 CEL；再评估是否继续保留少量复杂 webhook（例如强依赖外部系统查询或复杂状态编排的场景）。这样可以在不牺牲策略能力的前提下，逐步换取更可控的稳定性与变更成本。
+## 三、重点功能解读
 
-### 重点二：ServiceAccount Token 外部签名升级到 GA（KEP-740）
+### 重点一：细粒度 Kubelet API 鉴权进入稳定（KEP-2862）
 
-传统模式下，kube-apiserver 直接持有 ServiceAccount token 签名密钥，密钥生命周期与控制面节点绑定较深。对有合规要求或集中密钥管理要求的组织，这会带来审计、轮换、权限隔离上的治理压力。
+该能力在 v1.36 稳定化后，`kubelet` API 不再只能依赖粗粒度授权模型，运维与观测场景可按请求类型（如 `exec`、`logs`、`metrics`、`port-forward`）做更细粒度权限控制。对平台团队来说，这直接降低了“为了一个调试能力而放开整组高风险权限”的常见问题，是最小权限治理的一次实质推进。
 
-KEP-740 在 v1.36 的稳定化价值，在于把签名能力标准化地委托给外部系统（如 HSM、云 KMS），让 Kubernetes 与企业既有密钥治理体系对齐。它并不只是“换个签名位置”，而是把密钥保护边界、轮换流程和审计责任从单集群节点层面提升到统一安全基础设施层面。
+### 重点二：ServiceAccount Token 外部签名稳定化（KEP-740）
 
-实施时建议重点关注三件事：第一，签名链路延迟和可用性对认证路径的影响；第二，外部签名服务故障时的降级和恢复流程；第三，密钥轮换演练与审计证据闭环。做完这三项验证，外部签名才能真正转化为生产收益而不仅是架构升级。
+v1.36 将外部签名能力推进到稳定阶段，允许集群把 ServiceAccount Token 的签名职责委托给外部签名系统（如 HSM/KMS），而不必在控制面本地长期持有签名私钥。这一点对合规与密钥集中治理要求较高的组织尤其关键。
 
-### 重点三：Volume Group Snapshot 面向 GA（KEP-3476）
+结合 #55151 当前稿，稳定化后的关键价值不仅是“签名外置”，还包括更完整的控制面集成路径：apiserver 能发现并缓存外部签名方公钥、校验非本地签发 token，并与既有认证/RBAC 流程保持一致。对于已有外部 IAM 体系的平台，这意味着可以把 Kubernetes token 签发纳入统一密钥生命周期、轮换与审计机制。
 
-单卷快照难以覆盖多卷应用的一致性恢复诉求：当数据库数据卷、日志卷、元数据卷之间存在写入顺序关系时，分别快照往往无法保证同一恢复点。对训练平台、状态型中间件和复杂事务应用，这个问题在故障恢复时尤为明显。
+### 重点三：Volume Group Snapshot 稳定化（KEP-3476）
 
-Volume Group Snapshot 的核心价值，是把“多个相关卷”作为一个逻辑组进行快照与恢复，目标是提供 crash-consistent 的恢复点。它依赖 CSI 侧的一组扩展 API，能力边界清晰，也更利于存储厂商和平台团队在统一接口下协作。
+多卷应用的恢复一致性长期是生产痛点。v1.36 将 Volume Group Snapshot 推进到稳定后，平台可以对一组相关 PVC 做一致性快照与恢复，避免“单卷可恢复、多卷逻辑不一致”的问题。对训练平台、数据库及复杂有状态系统，这项能力更适合直接纳入 RTO/RPO 演练，而不是只做功能可用性验证。
 
-从平台实践看，这项能力最适合进入“备份恢复演练”而不仅是功能开关验证：建议把它纳入 RTO/RPO 目标校验，针对典型多卷工作负载做周期性恢复演练。只有把恢复链路跑通并量化结果，才能真正发挥该特性的业务价值。
+## 四、其他重要更新（结合 #55151 + #2958）
 
-## 三、其他 Highlights（每项一段）
+### Stable 侧
 
-### 1) 细粒度 Kubelet API 鉴权（KEP-2862，Stable）
+- Mutating Admission Policies（KEP-3962）进入稳定，进一步降低常见场景对外置 webhook 的依赖。
+- Declarative Validation（KEP-5073）进入稳定，校验规则更声明式、可维护。
+- 移除 gogo protobuf 依赖（KEP-5589）完成稳定落地。
+- Node Log Query（KEP-2258）稳定化，节点日志排障链路更统一。
+- User Namespaces（KEP-127）稳定化，容器内身份与宿主身份隔离更易落地。
+- PSI（KEP-4205）与 OCI VolumeSource（KEP-4639）稳定化，提升节点资源观测与数据分发路径能力。
 
-该能力允许按请求类型（如 exec、logs、metrics、port-forward）进行更细粒度授权，而不是把 kubelet 端点访问作为粗粒度权限整体放开。它的实际意义是让节点侧接口更接近最小权限模型，降低“拿到一种权限即可过度访问”的风险。
+### Beta 侧
 
-### 2) DRA AdminAccess for ResourceClaims（KEP-5018，Stable）
+- IP/CIDR 校验改进（KEP-4858）收紧非规范与歧义写法。
+- `kubectl` 用户偏好与集群配置分离（KEP-3104，`kuberc`）。
+- Suspended Job 资源可变（KEP-5440）。
+- Constrained Impersonation（KEP-5284）。
+- DRA 一组能力进入 beta（设备分区/污点容忍/状态可见性/扩展资源路径等）。
+- Statusz（KEP-4827）与 Flagz（KEP-4828）进入 beta 并默认启用。
+- Mixed Version Proxy（KEP-4020）进入 beta。
+- Memory QoS（KEP-2570）在 cgroup v2 语义下进一步完善。
 
-该特性支持以特权模式创建 ResourceClaim，用于在设备已被占用时执行管理类任务（如健康检查、状态查看）。对共享加速器环境而言，这有助于把“运维可见性”与“业务占用路径”解耦，减少排障时对业务负载的干扰。
+### Alpha 侧
 
-### 3) Constrained Impersonation（KEP-5284，Beta）
+- Staleness mitigation for controllers（KEP-5647）。
+- HPA Scale to Zero（KEP-2021）持续推进。
+- DRA Alpha 新增方向（与 Workload/可见性/原生资源适配相关）。
+- Native Histogram Support（KEP-5808）。
+- Manifest-based Admission Control Config（KEP-5793）。
+- CRI List Streaming（KEP-5825）。
 
-它允许发起模拟（impersonation）的一方主动将自身可用权限进一步收敛到子集，避免直接获得目标身份的完整权限视图。对多租户平台和审计敏感场景，这让模拟机制更适合纳入日常运维而非仅限特权操作。
+### 来自 #2958 的增量补充（3/31 与 4/2）
 
-### 4) IP/CIDR Validation Improvements（KEP-4858，Beta）
+- Node Log Query 在 SIG Windows 侧被明确标注为 v1.36 稳定能力，强调了跨 Linux/Windows 的统一节点日志排障路径。
+- SIG Node 强调 v1.36 的 DRA 是多能力线并行推进，同时补充了 CRI list streaming、Memory QoS、User Namespaces、PSI、OCI VolumeSource 等节点侧能力成熟度提升信号。
 
-该改动收紧了非规范和歧义 IP/CIDR 写法的接受范围，减少不同实现间解释不一致引发的安全与互通问题。升级前建议先做配置巡检，清理历史遗留的“可解析但不规范”地址写法，避免在发布窗口触发阻塞。
+### 升级风险前置：SELinux 兼容准备
 
-### 5) statusz / flagz（KEP-4827、KEP-4828，Beta）
-
-核心组件的 `/statusz` 与 `/flagz` 能力升级到 beta 且默认启用，使组件运行状态和关键配置暴露方式更一致。对平台可观测体系来说，这提升了控制面日常巡检和基线核对效率。
-
-### 6) Mixed Version Proxy（KEP-4020，Beta）
-
-该能力在版本偏斜场景下把请求转发到可处理该资源的 API Server，并提供更完整的聚合发现视图。它对“滚动升级中偶发 404/发现不一致”的缓解价值较高，适合作为升级窗口稳定性增强项来评估。
-
-### 7) HPA Scale to Zero（KEP-2021，Alpha）
-
-HPA 在 object/external metrics 场景支持从 0 到非 0 的伸缩能力，为事件驱动和低频工作负载提供更激进的成本优化空间。由于仍处于 Alpha，建议仅在边界可控场景试点，并明确冷启动与指标时效的观测基线。
-
-### 8) Workload Aware Scheduling（WAS）相关方向（SIG Scheduling）
-
-SIG Scheduling 在 #2958 中将 WAS 作为当前重点方向，关联 KEP 包括 5832、5732、5729、5710、5547、4671。该方向的核心目标是让调度器更理解“工作负载级”约束（如 PodGroup、拓扑与抢占协同），对 AI/批处理集群的价值尤其明显。
-
-### 9) Declarative Validation（KEP-5073，GA 方向）
-
-除 Mutating Admission Policy 外，Declarative Validation 的 GA 方向也值得作为 v1.36 重点叙事：它把“声明式校验”能力推进到更稳定阶段，帮助平台将部分分散在 webhook 或自定义控制器中的校验逻辑收敛到统一的 API 语义层。
-
-### 10) DRA 1.36 打包更新（稳定化 + 新能力并行）
-
-DRA 在 v1.36 的信号不是单点特性，而是多项能力并行推进：包括 prioritized list、extended resource、partitionable devices、device taints、binding conditions，以及 workload / native resource / visibility 等方向。对 AI 和异构算力平台，更建议将其作为一组“资源编排能力跃迁”来评估。
-
-### 11) User Namespaces（GA）落地实践
-
-User Namespaces 进入 GA 后，容器内用户与宿主机用户隔离的工程可用性更强，适合在多租户场景中与 RuntimeClass、seccomp、SELinux/AppArmor 等机制配套落地，形成“默认最小权限 + 分层隔离”的节点安全基线。
-
-### 12) 控制面可扩展性改进（KEP-5647、KEP-5866）
-
-controller staleness mitigation 与 server-side sharded list/watch 组合起来，分别针对控制器端陈旧状态影响与 apiserver 大规模 list/watch 压力做优化。两者的共同价值是把“控制面在大集群下的稳定性”从经验调优转向可机制化改进。
-
-### 13) SELinux 兼容准备（升级风险前置）
-
-虽然相关 breaking changes 主题常被放在后续版本窗口讨论，但其核心动作需要在 v1.36 周期前置完成：尽早盘点现有工作负载的 SELinux 相关假设与策略依赖，避免升级窗口内集中暴露兼容性问题。
-
-### 14) Node Log Query 进入稳定阶段（SIG Windows 补充）
-
-根据 #2958 在 2026-03-31 的补充，Node Log Query 在 v1.36 进入 stable，意味着通过 kubelet `/logs` 查询节点服务日志的能力进一步固化。该能力覆盖 Linux 与 Windows 节点，并可处理系统日志提供器与文件日志路径。对跨 OS 集群的运维价值在于：统一排障入口、减少节点侧“各自为政”的日志提取方式。
-
-从生产使用角度，仍需注意配置开关边界：虽然能力稳定化，但是否开放系统日志处理仍依赖 kubelet 配置项（`enableSystemLogHandler`），默认并非“全面开启”。建议将其作为“故障排查开关”纳入运维手册，而不是默认长期暴露。
-
-### 15) SIG Node 在 #2958 的新增重点：DRA 与节点能力并进
-
-根据 #2958 在 2026-04-02 的补充，SIG Node 强调 v1.36 的 DRA 不是单一功能升级，而是“多条能力线并行推进”：包括可分区设备、资源健康状态、扩展资源路径等。对平台侧的直接意义是，资源调度策略可以从“是否可分配”进一步走向“按健康度、按粒度、按回退策略分配”。
-
-同一批次补充里还强调了若干节点与运行时能力的成熟度提升，包括 User Namespaces、PSI 相关能力、OCI 卷源，以及 kubelet 侧针对大规模容器场景的 CRI list streaming 和 Memory QoS 行为调整。将这些点合并看待，更准确的解读是：v1.36 在“节点可扩展性 + 资源隔离精细化”方向上形成了联动改进，而不只是单点特性毕业。
+虽然 SELinux 相关潜在破坏性变更主要面向后续版本窗口讨论，但其准备动作应在 1.36 周期尽早完成。建议提前盘点工作负载的 SELinux 标签与策略假设，避免升级窗口集中暴露兼容性问题。
 
 > 说明：EvictionRequest API、HPA fallback external metrics、Deployment Pod Replacement Policy 相关稿件当前仍以占位探索为主，暂不作为本版 release 主线展开。
 
-## 四、建议的升级动作
+## 五、建议的升级动作
 
-1. 全量扫描清单与集群对象，完成 `externalIPs`、`gitRepo` 使用点盘点和迁移计划。
-2. 对入口层做维护状态审计，尽快推进 Ingress NGINX 迁移路线。
-3. 以 staging 为主验证准入策略、API Machinery 与调度相关改动，再逐步推进生产。
-4. 对多卷状态型业务执行组快照恢复演练，量化 RTO/RPO 并形成发布闸门。
-5. 升级当天对照最终 `CHANGELOG-1.36.md` 与 release notes 做差异复核。
+1. 先完成 `externalIPs` 与 `gitRepo` 使用面扫描，建立迁移清单和截止时间。
+2. 入口层尽快制定 Ingress NGINX 迁移方案与回退预案。
+3. 在 staging 验证：Kubelet 鉴权策略、外部 token 签名链路、准入策略变更路径。
+4. 对有状态关键业务执行组快照恢复演练，量化 RTO/RPO。
+5. 对大规模节点场景补充验证：Node Log Query、PSI、Memory QoS、CRI List Streaming 相关行为。
+6. GA 当日按最终 CHANGELOG/release notes 做一次差异复核再发版。
 
-## 五、参考链接
+## 六、参考链接
 
-- <https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/>
+- <https://github.com/kubernetes/website/pull/55151>
 - <https://github.com/kubernetes/sig-release/discussions/2958>
 - <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
 - <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
 - <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md>
-- <https://kep.k8s.io/5707>
-- <https://kep.k8s.io/5040>
-- <https://kep.k8s.io/3962>
 - <https://kep.k8s.io/740>
+- <https://kep.k8s.io/2862>
 - <https://kep.k8s.io/3476>

--- a/kubernetes/sig-release/v1.36/release.md
+++ b/kubernetes/sig-release/v1.36/release.md
@@ -1,107 +1,144 @@
-# Kubernetes v1.36 正式发布稿（对齐 release announcement 最新草稿）
+# Kubernetes v1.36 正式发布稿（精简版草案）
 
-> 写作基线：截至 **2026-04-20** 的上游公开信息，重点对齐 `kubernetes/website#55151`（updated at 2026-04-19）与 `kubernetes/sig-release#2958`。v1.36 计划发布时间为 **2026-04-22（周三）**，请以 GA 当日 CHANGELOG 与 release notes 为准。
+> 写作基线：截至 2026-04-20 的上游公开信息与 `kubernetes/sig-release#2958` 讨论内容。v1.36 计划发布时间为 2026-04-22（周三），正式发布当天请以 CHANGELOG 和 release notes 为准。
 
-## 一、升级必读（前瞻内容精简）
+本文结构按“前瞻精简 + highlights 展开”组织：
+- 前瞻里已经提到的内容，在这里做升级必读级别的精简提示。
+- `#2958` 讨论中的重点功能作为正文主线，提供相对完整说明。
 
-### 弃用与移除
+补充：结合 `kubernetes/website#55151` 当前最新 release announcement 草稿，v1.36 的高层信号可补充为：
 
-- `Service.spec.externalIPs`：v1.36 开始弃用并给出告警，计划 v1.43 移除。建议迁移到 `LoadBalancer`、`NodePort` 或 `Gateway API`（KEP-5707）。
-- `gitRepo` 卷驱动：v1.36 起永久禁用且不可重新启用。建议迁移为 `initContainer`、镜像构建打包或外部 `git-sync`（KEP-5040）。
+- 增强总量 70；其中 Stable 18、Beta 25、Alpha 25。
+- 官方 Spotlight 当前聚焦：细粒度 Kubelet API 鉴权（KEP-2862）、Resource Health Status（KEP-4680）、WAS 系列能力（含 KEP-5732）。
 
-### 生态风险提示
+## 一、升级必读（来自 prerelease，精简版）
 
-- Ingress NGINX 已于 2026 年 3 月 24 日退役，不再发布后续修复与安全更新。现网可继续运行，但应尽快推进迁移。
+### 1) 弃用与移除
 
-## 二、与 #55151 最新版本对齐的发布主线
+- `Service.spec.externalIPs`：v1.36 开始弃用并给出告警，计划 v1.43 移除。建议迁移到 `LoadBalancer`、`NodePort` 或 `Gateway API`。（KEP-5707）
+- `gitRepo` 卷驱动：v1.36 起永久禁用且不可重新启用。建议改为 `initContainer`、镜像构建阶段打包或外部 `git-sync`。（KEP-5040）
 
-根据 `kubernetes/website#55151` 当前草稿，v1.36 发布叙事已形成以下结构：
+### 2) 生态风险提示
 
-- 增强总量：**70**。
-- 升级到 Stable：**18**。
-- 升级到 Beta：**25**。
-- 升级到 Alpha：**25**。
+- Ingress NGINX 已在 2026 年 3 月退役，不再提供后续修复和安全更新。现网可继续运行，但建议尽快完成迁移方案评估。
 
-### Spotlight（官方草稿当前重点）
+## 二、Highlights Discussion 重点功能（展开版）
 
-- Stable：Fine-grained Kubelet API authorization（KEP-2862）。
-- Beta：Resource Health Status（KEP-4680）。
-- Alpha：Workload Aware Scheduling（WAS）系列能力（含 KEP-4671/5547/5832/5732/5710）。
+### 重点一：Mutating Admission Policies 升级到 GA（KEP-3962）
 
-## 三、重点功能解读
+过去很多团队依赖 mutating webhook 做策略注入、默认值补全和安全控制，但 webhook 体系本身有明显运维成本：需要额外部署与证书管理、故障会放大 API 请求路径风险、升级和排障链路也更长。对于多集群平台，这类“外置准入逻辑”通常是稳定性薄弱点之一。
 
-### 重点一：细粒度 Kubelet API 鉴权进入稳定（KEP-2862）
+v1.36 中，基于 CEL 的 Mutating Admission Policies 进入 GA，意味着“声明式、进程内”的变更准入能力进入稳定阶段。它与已 GA 的 Validating Admission Policy 形成闭环，让集群在“校验 + 变更”两个环节都能减少对外部 webhook 的硬依赖。对平台团队来说，最直接价值是把一部分高频、可声明化的准入逻辑收敛到 apiserver 内部能力，降低控制面外围组件复杂度。
 
-该能力在 v1.36 稳定化后，`kubelet` API 不再只能依赖粗粒度授权模型，运维与观测场景可按请求类型（如 `exec`、`logs`、`metrics`、`port-forward`）做更细粒度权限控制。对平台团队来说，这直接降低了“为了一个调试能力而放开整组高风险权限”的常见问题，是最小权限治理的一次实质推进。
+落地上建议采用分层迁移：先从无副作用、纯字段变换的 webhook 规则迁入 CEL；再评估是否继续保留少量复杂 webhook（例如强依赖外部系统查询或复杂状态编排的场景）。这样可以在不牺牲策略能力的前提下，逐步换取更可控的稳定性与变更成本。
 
-### 重点二：ServiceAccount Token 外部签名稳定化（KEP-740）
+### 重点二：ServiceAccount Token 外部签名升级到 GA（KEP-740）
 
-v1.36 将外部签名能力推进到稳定阶段，允许集群把 ServiceAccount Token 的签名职责委托给外部签名系统（如 HSM/KMS），而不必在控制面本地长期持有签名私钥。这一点对合规与密钥集中治理要求较高的组织尤其关键。
+传统模式下，kube-apiserver 直接持有 ServiceAccount token 签名密钥，密钥生命周期与控制面节点绑定较深。对有合规要求或集中密钥管理要求的组织，这会带来审计、轮换、权限隔离上的治理压力。
 
-结合 #55151 当前稿，稳定化后的关键价值不仅是“签名外置”，还包括更完整的控制面集成路径：apiserver 能发现并缓存外部签名方公钥、校验非本地签发 token，并与既有认证/RBAC 流程保持一致。对于已有外部 IAM 体系的平台，这意味着可以把 Kubernetes token 签发纳入统一密钥生命周期、轮换与审计机制。
+KEP-740 在 v1.36 的稳定化价值，在于把签名能力标准化地委托给外部系统（如 HSM、云 KMS），让 Kubernetes 与企业既有密钥治理体系对齐。它并不只是“换个签名位置”，而是把密钥保护边界、轮换流程和审计责任从单集群节点层面提升到统一安全基础设施层面。
 
-### 重点三：Volume Group Snapshot 稳定化（KEP-3476）
+实施时建议重点关注三件事：第一，签名链路延迟和可用性对认证路径的影响；第二，外部签名服务故障时的降级和恢复流程；第三，密钥轮换演练与审计证据闭环。做完这三项验证，外部签名才能真正转化为生产收益而不仅是架构升级。
 
-多卷应用的恢复一致性长期是生产痛点。v1.36 将 Volume Group Snapshot 推进到稳定后，平台可以对一组相关 PVC 做一致性快照与恢复，避免“单卷可恢复、多卷逻辑不一致”的问题。对训练平台、数据库及复杂有状态系统，这项能力更适合直接纳入 RTO/RPO 演练，而不是只做功能可用性验证。
+### 重点三：Volume Group Snapshot 面向 GA（KEP-3476）
 
-## 四、其他重要更新（结合 #55151 + #2958）
+单卷快照难以覆盖多卷应用的一致性恢复诉求：当数据库数据卷、日志卷、元数据卷之间存在写入顺序关系时，分别快照往往无法保证同一恢复点。对训练平台、状态型中间件和复杂事务应用，这个问题在故障恢复时尤为明显。
 
-### Stable 侧
+Volume Group Snapshot 的核心价值，是把“多个相关卷”作为一个逻辑组进行快照与恢复，目标是提供 crash-consistent 的恢复点。它依赖 CSI 侧的一组扩展 API，能力边界清晰，也更利于存储厂商和平台团队在统一接口下协作。
 
-- Mutating Admission Policies（KEP-3962）进入稳定，进一步降低常见场景对外置 webhook 的依赖。
-- Declarative Validation（KEP-5073）进入稳定，校验规则更声明式、可维护。
-- 移除 gogo protobuf 依赖（KEP-5589）完成稳定落地。
-- Node Log Query（KEP-2258）稳定化，节点日志排障链路更统一。
-- User Namespaces（KEP-127）稳定化，容器内身份与宿主身份隔离更易落地。
-- PSI（KEP-4205）与 OCI VolumeSource（KEP-4639）稳定化，提升节点资源观测与数据分发路径能力。
+从平台实践看，这项能力最适合进入“备份恢复演练”而不仅是功能开关验证：建议把它纳入 RTO/RPO 目标校验，针对典型多卷工作负载做周期性恢复演练。只有把恢复链路跑通并量化结果，才能真正发挥该特性的业务价值。
 
-### Beta 侧
+## 三、其他 Highlights（每项一段）
 
-- IP/CIDR 校验改进（KEP-4858）收紧非规范与歧义写法。
-- `kubectl` 用户偏好与集群配置分离（KEP-3104，`kuberc`）。
-- Suspended Job 资源可变（KEP-5440）。
-- Constrained Impersonation（KEP-5284）。
-- DRA 一组能力进入 beta（设备分区/污点容忍/状态可见性/扩展资源路径等）。
-- Statusz（KEP-4827）与 Flagz（KEP-4828）进入 beta 并默认启用。
-- Mixed Version Proxy（KEP-4020）进入 beta。
-- Memory QoS（KEP-2570）在 cgroup v2 语义下进一步完善。
+### 1) 细粒度 Kubelet API 鉴权（KEP-2862，Stable）
 
-### Alpha 侧
+该能力允许按请求类型（如 exec、logs、metrics、port-forward）进行更细粒度授权，而不是把 kubelet 端点访问作为粗粒度权限整体放开。它的实际意义是让节点侧接口更接近最小权限模型，降低“拿到一种权限即可过度访问”的风险。
 
-- Staleness mitigation for controllers（KEP-5647）。
-- HPA Scale to Zero（KEP-2021）持续推进。
-- DRA Alpha 新增方向（与 Workload/可见性/原生资源适配相关）。
-- Native Histogram Support（KEP-5808）。
-- Manifest-based Admission Control Config（KEP-5793）。
-- CRI List Streaming（KEP-5825）。
+### 2) DRA AdminAccess for ResourceClaims（KEP-5018，Stable）
 
-### 来自 #2958 的增量补充（3/31 与 4/2）
+该特性支持以特权模式创建 ResourceClaim，用于在设备已被占用时执行管理类任务（如健康检查、状态查看）。对共享加速器环境而言，这有助于把“运维可见性”与“业务占用路径”解耦，减少排障时对业务负载的干扰。
 
-- Node Log Query 在 SIG Windows 侧被明确标注为 v1.36 稳定能力，强调了跨 Linux/Windows 的统一节点日志排障路径。
-- SIG Node 强调 v1.36 的 DRA 是多能力线并行推进，同时补充了 CRI list streaming、Memory QoS、User Namespaces、PSI、OCI VolumeSource 等节点侧能力成熟度提升信号。
+### 3) Constrained Impersonation（KEP-5284，Beta）
 
-### 升级风险前置：SELinux 兼容准备
+它允许发起模拟（impersonation）的一方主动将自身可用权限进一步收敛到子集，避免直接获得目标身份的完整权限视图。对多租户平台和审计敏感场景，这让模拟机制更适合纳入日常运维而非仅限特权操作。
 
-虽然 SELinux 相关潜在破坏性变更主要面向后续版本窗口讨论，但其准备动作应在 1.36 周期尽早完成。建议提前盘点工作负载的 SELinux 标签与策略假设，避免升级窗口集中暴露兼容性问题。
+### 4) IP/CIDR Validation Improvements（KEP-4858，Beta）
+
+该改动收紧了非规范和歧义 IP/CIDR 写法的接受范围，减少不同实现间解释不一致引发的安全与互通问题。升级前建议先做配置巡检，清理历史遗留的“可解析但不规范”地址写法，避免在发布窗口触发阻塞。
+
+### 5) statusz / flagz（KEP-4827、KEP-4828，Beta）
+
+核心组件的 `/statusz` 与 `/flagz` 能力升级到 beta 且默认启用，使组件运行状态和关键配置暴露方式更一致。对平台可观测体系来说，这提升了控制面日常巡检和基线核对效率。
+
+### 6) Mixed Version Proxy（KEP-4020，Beta）
+
+该能力在版本偏斜场景下把请求转发到可处理该资源的 API Server，并提供更完整的聚合发现视图。它对“滚动升级中偶发 404/发现不一致”的缓解价值较高，适合作为升级窗口稳定性增强项来评估。
+
+### 7) HPA Scale to Zero（KEP-2021，Alpha）
+
+HPA 在 object/external metrics 场景支持从 0 到非 0 的伸缩能力，为事件驱动和低频工作负载提供更激进的成本优化空间。由于仍处于 Alpha，建议仅在边界可控场景试点，并明确冷启动与指标时效的观测基线。
+
+### 8) Workload Aware Scheduling（WAS）相关方向（SIG Scheduling）
+
+SIG Scheduling 在 #2958 中将 WAS 作为当前重点方向，关联 KEP 包括 5832、5732、5729、5710、5547、4671。该方向的核心目标是让调度器更理解“工作负载级”约束（如 PodGroup、拓扑与抢占协同），对 AI/批处理集群的价值尤其明显。
+
+### 8.1) 拓扑感知 Workload 调度（KEP-5732）专项说明
+
+`KEP-5732` 在 v1.36 处于 Alpha 推进阶段，核心不是“再加一个普通打分插件”，而是把拓扑约束（如机架/可用区/网络拓扑域）与 Workload/PodGroup 级调度语义联动起来，让调度决策从“单 Pod 可落点”升级为“整组工作负载跨拓扑放置成本”优化。结合 v1.35 已引入的 gang scheduling，v1.36 的重点是把“成组调度”进一步推进到“成组且拓扑感知调度”，以减少分布式训练与高通信负载任务中的跨拓扑通信放大和资源碎片化。
+
+从落地节奏看，这项能力仍是 Alpha，更适合在有明显拓扑瓶颈的场景做分层试点：先验证调度可行性与回退路径，再观察任务完成时延、网络热点与资源利用率变化，最后再扩大到更广泛工作负载。
+
+### 9) Declarative Validation（KEP-5073，GA 方向）
+
+除 Mutating Admission Policy 外，Declarative Validation 的 GA 方向也值得作为 v1.36 重点叙事：它把“声明式校验”能力推进到更稳定阶段，帮助平台将部分分散在 webhook 或自定义控制器中的校验逻辑收敛到统一的 API 语义层。
+
+### 10) DRA 1.36 打包更新（稳定化 + 新能力并行）
+
+DRA 在 v1.36 的信号不是单点特性，而是多项能力并行推进：包括 prioritized list、extended resource、partitionable devices、device taints、binding conditions，以及 workload / native resource / visibility 等方向。对 AI 和异构算力平台，更建议将其作为一组“资源编排能力跃迁”来评估。
+
+### 11) User Namespaces（GA）落地实践
+
+User Namespaces 进入 GA 后，容器内用户与宿主机用户隔离的工程可用性更强，适合在多租户场景中与 RuntimeClass、seccomp、SELinux/AppArmor 等机制配套落地，形成“默认最小权限 + 分层隔离”的节点安全基线。
+
+### 12) 控制面可扩展性改进（KEP-5647、KEP-5866）
+
+controller staleness mitigation 与 server-side sharded list/watch 组合起来，分别针对控制器端陈旧状态影响与 apiserver 大规模 list/watch 压力做优化。两者的共同价值是把“控制面在大集群下的稳定性”从经验调优转向可机制化改进。
+
+### 13) SELinux 兼容准备（升级风险前置）
+
+虽然相关 breaking changes 主题常被放在后续版本窗口讨论，但其核心动作需要在 v1.36 周期前置完成：尽早盘点现有工作负载的 SELinux 相关假设与策略依赖，避免升级窗口内集中暴露兼容性问题。
+
+### 14) Node Log Query 进入稳定阶段（SIG Windows 补充）
+
+根据 #2958 在 2026-03-31 的补充，Node Log Query 在 v1.36 进入 stable，意味着通过 kubelet `/logs` 查询节点服务日志的能力进一步固化。该能力覆盖 Linux 与 Windows 节点，并可处理系统日志提供器与文件日志路径。对跨 OS 集群的运维价值在于：统一排障入口、减少节点侧“各自为政”的日志提取方式。
+
+从生产使用角度，仍需注意配置开关边界：虽然能力稳定化，但是否开放系统日志处理仍依赖 kubelet 配置项（`enableSystemLogHandler`），默认并非“全面开启”。建议将其作为“故障排查开关”纳入运维手册，而不是默认长期暴露。
+
+### 15) SIG Node 在 #2958 的新增重点：DRA 与节点能力并进
+
+根据 #2958 在 2026-04-02 的补充，SIG Node 强调 v1.36 的 DRA 不是单一功能升级，而是“多条能力线并行推进”：包括可分区设备、资源健康状态、扩展资源路径等。对平台侧的直接意义是，资源调度策略可以从“是否可分配”进一步走向“按健康度、按粒度、按回退策略分配”。
+
+同一批次补充里还强调了若干节点与运行时能力的成熟度提升，包括 User Namespaces、PSI 相关能力、OCI 卷源，以及 kubelet 侧针对大规模容器场景的 CRI list streaming 和 Memory QoS 行为调整。将这些点合并看待，更准确的解读是：v1.36 在“节点可扩展性 + 资源隔离精细化”方向上形成了联动改进，而不只是单点特性毕业。
 
 > 说明：EvictionRequest API、HPA fallback external metrics、Deployment Pod Replacement Policy 相关稿件当前仍以占位探索为主，暂不作为本版 release 主线展开。
 
-## 五、建议的升级动作
+## 四、建议的升级动作
 
-1. 先完成 `externalIPs` 与 `gitRepo` 使用面扫描，建立迁移清单和截止时间。
-2. 入口层尽快制定 Ingress NGINX 迁移方案与回退预案。
-3. 在 staging 验证：Kubelet 鉴权策略、外部 token 签名链路、准入策略变更路径。
-4. 对有状态关键业务执行组快照恢复演练，量化 RTO/RPO。
-5. 对大规模节点场景补充验证：Node Log Query、PSI、Memory QoS、CRI List Streaming 相关行为。
-6. GA 当日按最终 CHANGELOG/release notes 做一次差异复核再发版。
+1. 全量扫描清单与集群对象，完成 `externalIPs`、`gitRepo` 使用点盘点和迁移计划。
+2. 对入口层做维护状态审计，尽快推进 Ingress NGINX 迁移路线。
+3. 以 staging 为主验证准入策略、API Machinery 与调度相关改动，再逐步推进生产。
+4. 对多卷状态型业务执行组快照恢复演练，量化 RTO/RPO 并形成发布闸门。
+5. 升级当天对照最终 `CHANGELOG-1.36.md` 与 release notes 做差异复核。
 
-## 六、参考链接
+## 五、参考链接
 
-- <https://github.com/kubernetes/website/pull/55151>
+- <https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/>
 - <https://github.com/kubernetes/sig-release/discussions/2958>
 - <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/README.md>
 - <https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md>
 - <https://github.com/kubernetes/sig-release/blob/master/releases/release-1.36/release-notes/release-notes-draft.md>
+- <https://kep.k8s.io/5707>
+- <https://kep.k8s.io/5040>
+- <https://kep.k8s.io/3962>
 - <https://kep.k8s.io/740>
-- <https://kep.k8s.io/2862>
 - <https://kep.k8s.io/3476>


### PR DESCRIPTION
## 变更说明
- 将 `kubernetes/sig-release/v1.36/release.md` 对齐到 `kubernetes/website#55151` 的当前结构与重点。
- 更新写作基线到 2026-04-20。
- 同步 release announcement 草稿中的版本统计与 Spotlight 主线。
- 更新并强化 1.36 外部签名（KEP-740）相关描述，使其与最新发布稿语义一致。
- 补充 Stable/Beta/Alpha 关键条目，统一为可直接用于发布的中文文稿结构。

## 备注
- 仅修改一个文件：`kubernetes/sig-release/v1.36/release.md`。
