### PR TITLE
[codex] add SIG CLI kubectl programming mode

### DIFF
--- a/kubernetes/sig-cli/README.md
+++ b/kubernetes/sig-cli/README.md
@@ -1,0 +1,7 @@
+# SIG CLI
+
+## 资料
+
+| 文件 | 作者 |
+| --- | --- |
+| [kubectl 编程模式.pdf](./kubectl%20编程模式.pdf) | zhouya0 |


### PR DESCRIPTION
## Summary
- Add a new `kubernetes/sig-cli` folder.
- Add `kubectl 编程模式.pdf`.
- Add a SIG CLI README that notes the material author as `zhouya0`.

## Impact
This makes the kubectl programming mode material available under the Kubernetes SIG CLI docs area with author attribution visible in the folder README.

## Validation
- Verified the PR branch contains only the SIG CLI README and PDF additions relative to `main`.
- No automated tests were run because this is a documentation asset addition.
